### PR TITLE
[Bug] Fix NPE when using BorderTreeNodeDecorator

### DIFF
--- a/src/main/java/hu/webarticum/treeprinter/AbstractTreeNode.java
+++ b/src/main/java/hu/webarticum/treeprinter/AbstractTreeNode.java
@@ -22,4 +22,17 @@ public abstract class AbstractTreeNode implements TreeNode {
         return getContent();
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof AbstractTreeNode)) {
+            return false;
+        }
+        return this.getContent().equals(((AbstractTreeNode) obj).getContent());
+    }
+
+    @Override
+    public int hashCode() {
+        return getContent().hashCode();
+    }
+
 }


### PR DESCRIPTION
Fix #3 

Hi, I am from Apache Doris(Incubating) project. And I found this wonderful tree printer tools.
I am going to introduce this tool to our project to print the SQL query plan and query profile tree.

But when I am using BorderTreeNodeDecorator, it will throw NPE. So I have to copy your code to
our repo to fix the bug. PR: https://github.com/apache/incubator-doris/pull/5475

Once you merge this PR and make a new release, I will remove the source code of this tree printer
from Doris and just using maven dependency.

Thank U!